### PR TITLE
Specify publisher and provider addresses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ipni/go-libipni v0.6.2
 	github.com/ipni/storetheindex v0.8.18
 	github.com/libp2p/go-libp2p v0.33.0
+	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-varint v0.0.7
@@ -71,7 +72,6 @@ require (
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
-	github.com/multiformats/go-multiaddr v0.12.2 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect

--- a/naam_test.go
+++ b/naam_test.go
@@ -43,6 +43,11 @@ import (
 const (
 	announceURL = "http://localhost:3001"  // indexer ingest URL
 	findURL     = "http://localhost:40080" // dhstore service URL
+	listenAddr  = "127.0.0.1:9876"
+	// multiaddr telling the indexer where to fetch advertisements from.
+	publisherAddr = "/ip4/127.0.0.1/tcp/9876/http"
+	// multiaddr to use as provider address in anvertisements.
+	providerAddr = "/dns4/ipfs.io/tcp/443/https"
 )
 
 func TestNaam(t *testing.T) {
@@ -59,9 +64,11 @@ func TestNaam(t *testing.T) {
 	require.NoError(t, err)
 
 	n, err := naam.New(naam.WithHost(h),
-		naam.WithHttpListenAddr("127.0.0.1"),
-		naam.WithHttpIndexerURL(announceURL),
-		naam.WithHttpFindURL(findURL),
+		naam.WithListenAddr(listenAddr),
+		naam.WithAnnounceURL(announceURL),
+		naam.WithFindURL(findURL),
+		naam.WithPublisherAddrs(publisherAddr),
+		naam.WithProviderAddrs(providerAddr),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
The publisher address is used to tell IPNI where to fetch advertisements from. It may be a public address different from the publisher listen address. So, it is necessary to explicitly specify the address.

The provider address is the provider address part of an advertisement. IPNI may require that this be a routable address and reject the advertisement if it is not. So, it is necessary to specify this address.